### PR TITLE
Feature/healthcheck refactor

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,6 +10,7 @@
   "node": true,
   "mocha": true,
   "globals": {
-    "app": true
+    "app": true,
+    "Promise": true
   }
 }

--- a/api/controllers/admin.js
+++ b/api/controllers/admin.js
@@ -17,7 +17,12 @@ function config(req, res) {
 function healthcheck(req, res) {
   require("../../lib/healthcheck/index.js")()
     .then(function(results){
-      res.json(results);
+      // If any tests have failed, return with a 503
+      var failures = results.tests.filter(function(e) {
+        return e.test_result === "failed";
+      });
+
+      res.status((failures.length > 0) ? 503 : 200).json(results);
     }).catch(function(results){
       res.status(503).json(results);
     });

--- a/api/controllers/admin.js
+++ b/api/controllers/admin.js
@@ -5,21 +5,6 @@ var statsdClient = app.get("statsd");
 var redisClient = app.get("redis");
 var db = app.get("db");
 
-// Store the last state of the different healthcheck tests that we run. The
-// /heathcheck route will return a 503 on the first failed check, but we can
-// at least return the statuses of the other checks, even if they are out of date.
-var tests = {
-  redis: {
-    test_name: "redis"
-  },
-  statsd: {
-    test_name: "statsd"
-  },
-  db: {
-    test_name: "database"
-  }
-};
-
 module.exports = {
   config: config,
   healthcheck: healthcheck
@@ -30,61 +15,10 @@ function config(req, res) {
 }
 
 function healthcheck(req, res) {
-  var reportStart = process.hrtime();
-  var report = {
-    report_as_of: new Date().toISOString(),
-    duration_millis: 0,
-    tests: []
-  };
-
-  var redisStart = process.hrtime();
-  tests.redis.tested_at = new Date().toISOString();
-  redisClient.ping(function(err, result) {
-    tests.redis.duration_millis = elapsed_time(redisStart);
-    if (err) {
-      tests.redis.test_result = "failed";
-      finalizeReport(report, reportStart);
-      res.status(503).json(report);
-    } else {
-      tests.redis.test_result = "passed";
-
-      var statsdStart = process.hrtime();
-      tests.statsd.tested_at = new Date().toISOString();
-      statsdClient.increment("healthcheck", 1, 1, function(err, bytes) {
-
-        tests.statsd.duration_millis = elapsed_time(statsdStart);
-        if (err) {
-          tests.statsd.test_result = "failed";
-          finalizeReport(report, reportStart);
-          res.status(503).json(report);
-        } else {
-          tests.statsd.test_result = "passed";
-          var dbStart = process.hrtime();
-          tests.db.tested_at = new Date().toISOString();
-          db.Deployment.findOne().catch(function(error) {
-            tests.db.duration_millis = elapsed_time(dbStart);
-            tests.db.test_result = "failed";
-            finalizeReport(report, reportStart);
-            res.status(503).json(report);
-          }).then(function(deployment) {
-            tests.db.duration_millis = elapsed_time(dbStart);
-            tests.db.test_result = "passed";
-            finalizeReport(report, reportStart);
-            res.json(report);
-          });
-        }
-      });
-    }
-  });
+  require("../../lib/healthcheck/index.js")()
+    .then(function(results){
+      res.json(results);
+    }).catch(function(results){
+      res.status(503).json(results);
+    });
 }
-
-function finalizeReport(report, reportStart) {
-  report.tests.push(tests.redis);
-  report.tests.push(tests.statsd);
-  report.tests.push(tests.db);
-  report.duration_millis = elapsed_time(reportStart);
-}
-
-var elapsed_time = function(start){
-  return (process.hrtime(start)[1] / 1000000).toFixed(1); // divide by a million to get nano to milli
-};

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -261,7 +261,7 @@ paths:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse"
+            $ref: "#/definitions/ObjectResponse"
 definitions:
   ObjectResponse:
     properties:

--- a/lib/healthcheck/db.js
+++ b/lib/healthcheck/db.js
@@ -8,24 +8,24 @@ function elapsed_time (start){
 
 function runTest(resolve, reject) {
   var results = { test_name: "db" },
-      dbStart = process.hrtime();
+      start = process.hrtime();
 
   results.tested_at = new Date().toISOString();
   try {
     db.Deployment.findOne().catch(function(error) {
-      results.duration_millis = elapsed_time(dbStart);
+      results.duration_millis = elapsed_time(start);
       results.error = error.message;
       results.test_result = "failed";
       resolve(results);
     }).then(function(deployment) {
-      results.duration_millis = elapsed_time(dbStart);
+      results.duration_millis = elapsed_time(start);
       results.test_result = "passed";
       resolve(results);
     });
   } catch(err) {
     results.test_result = "failed";
     results.error = err;
-    results.duration_millis = elapsed_time(dbStart);
+    results.duration_millis = elapsed_time(start);
     resolve(results);
   }
 }

--- a/lib/healthcheck/db.js
+++ b/lib/healthcheck/db.js
@@ -7,7 +7,7 @@ function elapsed_time (start){
 }
 
 function runTest(resolve, reject) {
-  var results = { name: "db" },
+  var results = { test_name: "db" },
       dbStart = process.hrtime();
 
   results.tested_at = new Date().toISOString();

--- a/lib/healthcheck/db.js
+++ b/lib/healthcheck/db.js
@@ -1,0 +1,35 @@
+"use strict";
+
+var db = require("../../data/models/index.js");
+
+function elapsed_time (start){
+  return (process.hrtime(start)[1] / 1000000).toFixed(1); // divide by a million to get nano to milli
+}
+
+function runTest(resolve, reject) {
+  var results = { name: "db" },
+      dbStart = process.hrtime();
+
+  results.tested_at = new Date().toISOString();
+  try {
+    db.Deployment.findOne().catch(function(error) {
+      results.duration_millis = elapsed_time(dbStart);
+      results.error = error.message;
+      results.test_result = "failed";
+      resolve(results);
+    }).then(function(deployment) {
+      results.duration_millis = elapsed_time(dbStart);
+      results.test_result = "passed";
+      resolve(results);
+    });
+  } catch(err) {
+    results.test_result = "failed";
+    results.error = err;
+    results.duration_millis = elapsed_time(dbStart);
+    resolve(results);
+  }
+}
+
+module.exports = function() {
+  return new Promise(runTest);
+};

--- a/lib/healthcheck/index.js
+++ b/lib/healthcheck/index.js
@@ -1,0 +1,47 @@
+"use strict";
+
+var fs        = require("fs");
+var path      = require("path");
+var basename  = path.basename(module.filename);
+var logger    = require("../logger.js").getLogger({"module": __filename});
+
+module.exports = function () {
+  var reportStart = process.hrtime();
+  var report = {
+    report_as_of: new Date().toISOString(),
+    duration_millis: 0,
+    tests: []
+  };
+
+  // Load up an array of promises for each (other) file in this directory
+  // All tests should resolve and never reject to avoid breaking other tests
+  var tests = [];
+  fs.readdirSync(__dirname)
+    .filter(function(file) {
+      return (file.indexOf(".") !== 0) && (file !== basename);
+    })
+    .forEach(function(file) {
+      logger.info("Running test: " + file);
+      tests.push(require("./" + file)());
+    });
+
+  // Once all promises have resolved, return the report
+  return Promise.all(tests)
+      .then(function (results) {
+        report.tests = results;
+        finalizeReport(report, reportStart);
+        return report;
+      }).catch(function (results) {
+        report.tests = results;
+        finalizeReport(report, reportStart);
+        return report;
+      });
+};
+
+function finalizeReport(report, reportStart) {
+  report.duration_millis = elapsed_time(reportStart);
+}
+
+var elapsed_time = function(start){
+  return (process.hrtime(start)[1] / 1000000).toFixed(1); // divide by a million to get nano to milli
+};

--- a/lib/healthcheck/redis.js
+++ b/lib/healthcheck/redis.js
@@ -7,7 +7,7 @@ function elapsed_time (start){
 }
 
 function runTest(resolve, reject) {
-  var results = { name: "redis" },
+  var results = { test_name: "redis" },
       redisStart = process.hrtime();
 
   results.tested_at = new Date().toISOString();

--- a/lib/healthcheck/redis.js
+++ b/lib/healthcheck/redis.js
@@ -8,7 +8,7 @@ function elapsed_time (start){
 
 function runTest(resolve, reject) {
   var results = { test_name: "redis" },
-      redisStart = process.hrtime();
+      start = process.hrtime();
 
   results.tested_at = new Date().toISOString();
   try{
@@ -19,13 +19,13 @@ function runTest(resolve, reject) {
       } else {
         results.test_result = "passed";
       }
-      results.duration_millis = elapsed_time(redisStart);
+      results.duration_millis = elapsed_time(start);
       resolve(results);
     });
   } catch(err) {
     results.test_result = "failed";
     results.error = err;
-    results.duration_millis = elapsed_time(redisStart);
+    results.duration_millis = elapsed_time(start);
     resolve(results);
   }
 }

--- a/lib/healthcheck/redis.js
+++ b/lib/healthcheck/redis.js
@@ -1,0 +1,35 @@
+"use strict";
+var config = require("../../config.js"),
+    redisClient = require("../../lib/redis.js").init(config.redis || {});
+
+function elapsed_time (start){
+  return (process.hrtime(start)[1] / 1000000).toFixed(1); // divide by a million to get nano to milli
+}
+
+function runTest(resolve, reject) {
+  var results = { name: "redis" },
+      redisStart = process.hrtime();
+
+  results.tested_at = new Date().toISOString();
+  try{
+    redisClient.ping(function(err, result) {
+      if (err) {
+        results.test_result = "failed";
+        results.error = err.message;
+      } else {
+        results.test_result = "passed";
+      }
+      results.duration_millis = elapsed_time(redisStart);
+      resolve(results);
+    });
+  } catch(err) {
+    results.test_result = "failed";
+    results.error = err;
+    results.duration_millis = elapsed_time(redisStart);
+    resolve(results);
+  }
+}
+
+module.exports = function() {
+  return new Promise(runTest);
+};

--- a/lib/healthcheck/statsd.js
+++ b/lib/healthcheck/statsd.js
@@ -1,0 +1,37 @@
+"use strict";
+
+var config = require("../../config.js"),
+    statsdClient = require("../../lib/statsd.js").init(config.statsd || {});
+
+function elapsed_time (start){
+  return (process.hrtime(start)[1] / 1000000).toFixed(1); // divide by a million to get nano to milli
+}
+
+function runTest(resolve, reject) {
+  var results = { name: "statsd" },
+      statsdStart = process.hrtime();
+
+  results.tested_at = new Date().toISOString();
+  try {
+    statsdClient.increment("healthcheck", 1, 1, function(err, bytes) {
+      if (err) {
+        results.error = err.message;
+        results.test_result = "failed";
+      } else {
+        results.test_result = "passed";
+      }
+
+      results.duration_millis = elapsed_time(statsdStart);
+      resolve(results);
+    });
+  } catch(err) {
+    results.test_result = "failed";
+    results.error = err.message;
+    results.duration_millis = elapsed_time(statsdStart);
+    resolve(results);
+  }
+}
+
+module.exports = function() {
+  return new Promise(runTest);
+};

--- a/lib/healthcheck/statsd.js
+++ b/lib/healthcheck/statsd.js
@@ -9,7 +9,7 @@ function elapsed_time (start){
 
 function runTest(resolve, reject) {
   var results = { test_name: "statsd" },
-      statsdStart = process.hrtime();
+      start = process.hrtime();
 
   results.tested_at = new Date().toISOString();
   try {
@@ -21,13 +21,13 @@ function runTest(resolve, reject) {
         results.test_result = "passed";
       }
 
-      results.duration_millis = elapsed_time(statsdStart);
+      results.duration_millis = elapsed_time(start);
       resolve(results);
     });
   } catch(err) {
     results.test_result = "failed";
     results.error = err.message;
-    results.duration_millis = elapsed_time(statsdStart);
+    results.duration_millis = elapsed_time(start);
     resolve(results);
   }
 }

--- a/lib/healthcheck/statsd.js
+++ b/lib/healthcheck/statsd.js
@@ -8,7 +8,7 @@ function elapsed_time (start){
 }
 
 function runTest(resolve, reject) {
-  var results = { name: "statsd" },
+  var results = { test_name: "statsd" },
       statsdStart = process.hrtime();
 
   results.tested_at = new Date().toISOString();


### PR DESCRIPTION
Make the healthchecks more promisey. All checks now run each time instead of callbacking and short-circuiting. New checks can be added by just dropping an additional file in `/lib/healthcheck` that returns a `Promise` that resolves with test results.
