### PR TITLE
Assert server result

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -311,6 +311,9 @@ definitions:
       elapsed_seconds:
         type: integer
         description: The elapsed time of the deployment, in seconds
+      assert_empty_server_result:
+        type: boolean
+        description: Whether or not to assert the result of a deployment to any server that doesn't have a result at the time the deployment is marked complete
       servers:
         type: array
         description: The servers that participated in the deployment

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-tracker",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Collect deployment metadata and store it in purpose-driven data stores",
   "keywords": [],

--- a/test/api/controllers/deployments.js
+++ b/test/api/controllers/deployments.js
@@ -36,7 +36,6 @@ describe("controllers", function() {
       });
     });
 
-
     describe("GET /v1/deployments/{id}", function() {
       it("Should be able to retrieve a recently created deployment", function(done) {
         request(server)
@@ -51,6 +50,24 @@ describe("controllers", function() {
             body.should.have.property("version", "4.5.6");
             done();
         });
+      });
+    });
+
+    describe("POST /v1/deployment/{id}/servers", function() {
+      it("Should create a server start record", function(done) {
+        request(server)
+          .post("/v1/deployments/" + deployment_id + "/servers")
+          .send({
+            deployment_id: deployment_id,
+            hostname: "hostname"
+          })
+          .end(function(err, res) {
+            if (err) {
+              throw err;
+            }
+            res.should.have.property("status", 201);
+            done();
+          });
       });
     });
 
@@ -83,7 +100,6 @@ describe("controllers", function() {
               throw err;
             }
             var body = res.body;
-
             // These are reverse-ordered, so the first one should be the one we just created.
             body[0].should.have.property("deployment_id", deployment_id);
             done();

--- a/test/api/controllers/deployments.js
+++ b/test/api/controllers/deployments.js
@@ -76,7 +76,8 @@ describe("controllers", function() {
         var status = {
           deployment_id: deployment_id,
           result: "success",
-          elapsed_seconds: 234
+          elapsed_seconds: 234,
+          assert_empty_server_result: true
         };
         request(server)
           .put("/v1/deployments/" + deployment_id)


### PR DESCRIPTION
Given that a deployment was started and zero or more server deployments were started
When a PUT /v1/deployments/{ID} request is made with the `assert_empty_server_results` boolean asserted and a `result` is provided
Then record the given result to any servers that currently don't have a result

This is targeted at the case where a deployment on a server is started and some exceptional thing happens making it hard or impossible to record the failure of that server deployment. 

This will not change elapsed_seconds at the server level.

@maclennann @potashj
