### PR TITLE
Rationalize statsd metric names to make them more navigable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+0.1.4 (July 6th, 2015)
+
+  - Rationalize statsd metrics to make them more easily navigable.
+
+0.1.3 (July 6th, 2015)
+
+  - Use the statsd config passed in, not the global config hash.

--- a/api/controllers/logs.js
+++ b/api/controllers/logs.js
@@ -15,6 +15,6 @@ function postLogs(req, res) {
   var message = req.swagger.params.body.value;
   message.deployment_id = req.swagger.params.id.value;
   redisClient.rpush("deployment-tracker", JSON.stringify(message));
-  statsdClient.increment("log_message");
+  statsdClient.increment("logs.message");
   res.status(201).end();
 }

--- a/api/controllers/servers.js
+++ b/api/controllers/servers.js
@@ -19,7 +19,7 @@ function postServer(req, res) {
 
     db.Server.build(server).save()
       .then(function(server) {
-        statsdClient.increment(server.hostname + ".started");
+        statsdClient.increment("servers.hostname." + statsdClient.escape(server.hostname) + ".started");
         res.location("/deployments/" + server.deployment_id + "/servers/" + server.hostname);
         res.status(201).end();
       })
@@ -38,9 +38,10 @@ function putServer(req, res) {
       hostname: server.hostname,
       deployment_id: server.deployment_id
     }
-  }).then(function (server) {
-    statsdClient.increment(server.hostname + "." + server.result);
-    statsdClient.timing(server.hostname + ".elapsed", server.elapsed_seconds);
+  }).then(function (count) {
+    var hostname = statsdClient.escape(server.hostname);
+    statsdClient.increment("servers.hostname." + hostname + "." + server.result);
+    statsdClient.timing("servers.hostname." + hostname + ".elapsed", server.elapsed_seconds);
 
     res.status(204).end();
   }).catch(function (err) {

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -11,6 +11,10 @@ module.exports.init = function(config) {
       logger.error("Error in statsd socket: ", err);
     });
 
+    statsdClient.escape = function(s) {
+      return s.replace(".", "_");
+    };
+
     return statsdClient;
   } catch(e) {
     logger.fatal(e, "Unable to create statsd_client targeting host %s", config.host);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-tracker",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "Collect deployment metadata and store it in purpose-driven data stores",
   "keywords": [],


### PR DESCRIPTION
This should create a stats hierarchy as follows:
- deployment-tracker/
  - deployments/
    - started
    - success
    - failure
    - elapsed
    - environments/
      - {environment}/
        - packages/
          - {package}/
            - started
            - success
            - failure
            - elapsed
  - servers/
    - {hostname}/
      - started
      - success
      - failure
      - elapsed
  - logs/
    - message

@maclennann @potashj
