### PR TITLE
Add config options for more redis functionality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.1.9 (July 8th, 2015)
+
+  - Add support for redis config values such as key, index, and additional_fields.
+
 0.1.5 (July 7th, 2015)
 
   - Bump version for first publish to npm

--- a/api/controllers/deployments.js
+++ b/api/controllers/deployments.js
@@ -39,8 +39,9 @@ function postDeployment(req, res) {
     logger.debug("Successfully created deployment" + deployment.id);
     logger.trace(deployment);
 
-    deployment.message = "Deployment Tracker recording deployment start for deployment " + deployment.deployment_id;
-    redisClient.rpush("deployment-tracker", JSON.stringify(deployment), function(err, result) {
+    var log = redisClient.updateLogMessage(deployment.get());
+    log.message = "Deployment Tracker recording deployment start for deployment " + deployment.deployment_id;
+    redisClient.rpush(redisClient.key, JSON.stringify(log), function(err, result) {
       if (err) {
         res.status(500).json({ "error": err.message});
       }
@@ -91,8 +92,9 @@ function putDeployment(req, res) {
           assertEmptyServerResult(deployment.deployment_id, deployment.result);
         }
 
-        deployment.message = "Deployment Tracker recording deployment end for deployment " + deployment.deployment_id;
-        redisClient.rpush("deployment-tracker", JSON.stringify(deployment), function(err, result) {
+        var log = redisClient.updateLogMessage(deployment.get());
+        log.message = "Deployment Tracker recording deployment end for deployment " + deployment.deployment_id;
+        redisClient.rpush(redisClient.key, JSON.stringify(log), function(err, result) {
           if (err) {
             res.status(500).json({ "error": err.message});
           }

--- a/api/controllers/logs.js
+++ b/api/controllers/logs.js
@@ -14,7 +14,8 @@ module.exports = {
 function postLogs(req, res) {
   var message = req.swagger.params.body.value;
   message.deployment_id = req.swagger.params.id.value;
-  redisClient.rpush("deployment-tracker", JSON.stringify(message), function(err, result) {
+  message = redisClient.updateLogMessage(message);
+  redisClient.rpush(redisClient.key, JSON.stringify(message), function(err, result) {
     if (err) {
       res.status(500).json({ "error" : err.message});
     } else {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var logger = require("./logger.js").getLogger({"module": __filename});
+var _ = require("lodash");
 
 module.exports.init = function(config) {
   try {
@@ -21,6 +22,15 @@ module.exports.init = function(config) {
     redisClient.on("error", function (err) {
       logger.error(err, "Error caught from redis_client.");
     });
+
+    redisClient.key = config.key || "logstash";
+
+    // Add index and addtional_fields to the log message and return it
+    redisClient.updateLogMessage = function(message) {
+      message.index = config.index || "deployment-tracker";
+      _.assign(message, config.additional_fields || {});
+      return message;
+    };
 
     return redisClient;
   } catch(e) {


### PR DESCRIPTION
Redis key to send messages to, index name, and a hash of additional fields to add.

This will make it possible to finely control the interaction with the redis endpoint and downstream logstash / elasticsearch collector via the key, index, and additional_fields parameters without having to redeploy the app.

See readme for a more detailed explanation of the parameters and what impact they have.

@maclennann @potashj
