### PR TITLE
Merge application and DB configuration

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ var swaggerConfig = {
   appRoot: __dirname // required config
 };
 
-var config = require("./config.js");
+var config = require("./config.json");
 
 var logger = require("./lib/logger.js").getLogger({"module": __filename});
 logger.info("Deployment Tracker starting up.");

--- a/config.js
+++ b/config.js
@@ -1,9 +1,0 @@
-module.exports = {
-  redis: {
-    host: "127.0.0.1"
-  },
-  statsd: {
-    host: "127.0.0.1",
-    prefix: "deployment-tracker."
-  }
-};

--- a/config.json
+++ b/config.json
@@ -1,0 +1,15 @@
+{
+  "redis": {
+    "host": "127.0.0.1"
+  },
+  "statsd": {
+    "host": "127.0.0.1",
+    "prefix": "deployment-tracker."
+  },
+  "database": {
+    "development": {
+      "storage": "data.sqlite3",
+      "dialect": "sqlite"
+    }
+  }
+}

--- a/data/config/config.json
+++ b/data/config/config.json
@@ -1,6 +1,0 @@
-{
-  "development": {
-    "storage": "data.sqlite3",
-    "dialect": "sqlite"
-  }
-}

--- a/data/migrations/20150714073611-initializeDatabase.js
+++ b/data/migrations/20150714073611-initializeDatabase.js
@@ -1,0 +1,64 @@
+"use strict";
+
+module.exports = {
+  up: function (queryInterface, DataTypes) {
+    queryInterface.createTable("Deployments", {
+      deployment_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        primaryKey: true
+      },
+      engine: DataTypes.STRING,
+      engine_version: DataTypes.STRING,
+      host: DataTypes.STRING,
+      user: DataTypes.STRING,
+      environment: DataTypes.STRING,
+      package: DataTypes.STRING,
+      package_url: DataTypes.STRING,
+      version: DataTypes.STRING,
+      arguments: DataTypes.STRING,
+      result: DataTypes.STRING,
+      elapsed_seconds: DataTypes.INTEGER,
+      createdAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      }
+    });
+
+    queryInterface.createTable("Servers", {
+      hostname: {
+        type: DataTypes.STRING,
+        primaryKey: true
+      },
+
+      deployment_id: {
+        type: DataTypes.UUID,
+        primaryKey: true,
+        references: "Deployments",
+        referencesKey: "deployment_id",
+        onDelete: "cascade",
+        onUpdate: "cascade"
+      },
+
+      ip_address: DataTypes.STRING,
+      result: DataTypes.STRING,
+      elapsed_seconds: DataTypes.INTEGER,
+      createdAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      }
+    });
+  },
+  down: function (queryInterface, Sequelize) {
+    queryInterface.dropTable("Servers");
+    queryInterface.dropTable("Deployments");
+  }
+};

--- a/data/models/index.js
+++ b/data/models/index.js
@@ -5,7 +5,7 @@ var path      = require("path");
 var Sequelize = require("sequelize");
 var basename  = path.basename(module.filename);
 var env       = process.env.NODE_ENV || "development";
-var config    = require(__dirname + "/../config/config.json")[env];
+var config    = require(__dirname + "/../../config.json").database[env];
 var sequelize = new Sequelize(config.database, config.username, config.password, config);
 var db        = {};
 

--- a/data/models/index.js
+++ b/data/models/index.js
@@ -27,8 +27,6 @@ Object.keys(db).forEach(function(modelName) {
   }
 });
 
-sequelize.sync();
-
 db.sequelize = sequelize;
 db.Sequelize = Sequelize;
 

--- a/lib/healthcheck/redis.js
+++ b/lib/healthcheck/redis.js
@@ -1,5 +1,5 @@
 "use strict";
-var config = require("../../config.js"),
+var config = require("../../config.json"),
     redisClient = require("../../lib/redis.js").init(config.redis || {});
 
 function elapsed_time (start){

--- a/lib/healthcheck/statsd.js
+++ b/lib/healthcheck/statsd.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var config = require("../../config.js"),
+var config = require("../../config.json"),
     statsdClient = require("../../lib/statsd.js").init(config.statsd || {});
 
 function elapsed_time (start){

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "sequelize": "^3.1.1",
     "sqlite3": "^3.0.8",
     "swagger-express-mw": "0.0.x",
-    "swagger-node-express": "^2.1.3"
+    "swagger-node-express": "^2.1.3",
+    "umzug": "^1.6.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/test/api/controllers/admin.js
+++ b/test/api/controllers/admin.js
@@ -7,6 +7,20 @@ var server = require("../../../app");
 process.env.A127_ENV = "test";
 
 describe("controllers", function() {
+
+  // Before running any tests, give the application time to start up.
+  // Since we're running migrations at app start, it's possible express
+  // wouldn't yet be listening by the time we start running tests against
+  // it.
+  before(function(done){
+    this.timeout(5000);
+    setTimeout(function () {
+      request(server).get("/")
+        .end(function(err,res){
+          done();
+        });
+    }, 2000);
+  });
   describe("admin", function() {
     describe("GET /config", function() {
       it("can retrieve config", function(done) {
@@ -16,9 +30,11 @@ describe("controllers", function() {
             if (err) {
               throw err;
             }
+
             res.should.have.property("status", 200);
             var config = require("../../../config.json");
             res.body.should.eql(config);
+
             done();
           });
       });

--- a/test/api/controllers/admin.js
+++ b/test/api/controllers/admin.js
@@ -17,7 +17,7 @@ describe("controllers", function() {
               throw err;
             }
             res.should.have.property("status", 200);
-            var config = require("../../../config.js");
+            var config = require("../../../config.json");
             res.body.should.eql(config);
             done();
           });


### PR DESCRIPTION
Put the database config into the toplevel `config.json` instead of being hidden inside of `data/config`.

This also required a `before` hook to the tests to, essentially, just "wait for the DB to migrate" if applicable. Otherwise, Express may not be listening when we start running tests against it.

Ideally, we might separate the DB stuff from the API handler from the business logic and test them separately. But it's probably not worth it (a) for an app this size (b) at this stage.
