### PR TITLE
Put a 2 second cap on the redis ping healthcheck.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,28 @@
+0.1.12 (Unreleased)
+
+  - Force the redis healthcheck (ping) to timeout after 2 seconds. This will cause
+  the healthcheck to return either a 503 of 200 after 2 seconds, rather than timing
+  out, which provides no insight into the health of the undelying components.
+
+0.1.11 (July 14th, 2015)
+
+  - Combine the configuration that was defined in the data/config/config.js file
+  with the rest of the application configuration that lived at the root level config.js.
+  - Rename the config.js file at the root of the project to config.json and update
+  the format accordingly.
+
+0.1.10 (July 13th, 2015)
+
+  - POST /deployment/{ID}/logs now accepts an array of log messages to allow for
+  more efficient batch delivery.
+
 0.1.9 (July 8th, 2015)
 
   - Add support for redis config values such as key, index, and additional_fields.
 
 0.1.5 (July 7th, 2015)
 
-  - Bump version for first publish to npm
+  - Bump version for first publish to npm.
 
 0.1.4 (July 6th, 2015)
 

--- a/lib/healthcheck/redis.js
+++ b/lib/healthcheck/redis.js
@@ -22,6 +22,7 @@ function runTest(resolve, reject) {
       resolve(results);
     }, 2000);
     redisClient.ping(function(err, result) {
+      clearTimeout();
       if (err) {
         results.test_result = "failed";
         results.error = err.message;

--- a/lib/healthcheck/redis.js
+++ b/lib/healthcheck/redis.js
@@ -12,6 +12,15 @@ function runTest(resolve, reject) {
 
   results.tested_at = new Date().toISOString();
   try{
+    // The ping call seems to go out to lunch and never return if it doesn't have
+    // a good redis connection, which means that we can't reason about the state
+    // of the other dependencies. I'd rather force a timeout.
+    setTimeout(function() {
+      results.test_result = "failed";
+      results.duration_millis = elapsed_time(start);
+      results.error = "timeout";
+      resolve(results);
+    }, 2000);
     redisClient.ping(function(err, result) {
       if (err) {
         results.test_result = "failed";


### PR DESCRIPTION
What was happening in practice was that if the redis connection was not available, this call would never return, which meant that we couldn't get the healthcheck report about the other components of the application. I'd rather cap the time this call can take and report back "failed" if we don't hear back in that amount of time. 

/cc @maclennann @potashj
