### PR TITLE
Make healthceck conform to new spec. Remove redundant "test" from "te…

### DIFF
--- a/api/controllers/admin.js
+++ b/api/controllers/admin.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var util = require("util"),
+var _ = require("lodash"),
+    util = require("util"),
     statsdClient = app.get("statsd"),
     redisClient = app.get("redis"),
     db = app.get("db"),
@@ -19,12 +20,8 @@ function healthcheck(req, res) {
   require("../../lib/healthcheck/index.js")()
     .then(function(results){
       // If any tests have failed, return with a 503
-      var failures = [];
-      Object.keys(results.tests).forEach(function (key) {
-        var value = results.tests[key];
-        if (value.result === "failed") {
-          failures.push(value);
-        }
+      var failures = _.map(results.tests).filter(function(e) {
+        return e.result === "failed";
       });
       res.status((failures.length > 0) ? 503 : 200).json(results);
     }).catch(function(results){

--- a/api/controllers/admin.js
+++ b/api/controllers/admin.js
@@ -19,10 +19,13 @@ function healthcheck(req, res) {
   require("../../lib/healthcheck/index.js")()
     .then(function(results){
       // If any tests have failed, return with a 503
-      var failures = results.tests.filter(function(e) {
-        return e.test_result === "failed";
+      var failures = [];
+      Object.keys(results.tests).forEach(function (key) {
+        var value = results.tests[key];
+        if (value.result === "failed") {
+          failures.push(value);
+        }
       });
-
       res.status((failures.length > 0) ? 503 : 200).json(results);
     }).catch(function(results){
       res.status(503).json(results);

--- a/lib/healthcheck/db.js
+++ b/lib/healthcheck/db.js
@@ -15,15 +15,15 @@ function runTest(resolve, reject) {
     db.Deployment.findOne().catch(function(error) {
       results.duration_millis = elapsed_time(start);
       results.error = error.message;
-      results.test_result = "failed";
+      results.result = "failed";
       resolve(results);
     }).then(function(deployment) {
       results.duration_millis = elapsed_time(start);
-      results.test_result = "passed";
+      results.result = "passed";
       resolve(results);
     });
   } catch(err) {
-    results.test_result = "failed";
+    results.result = "failed";
     results.error = err;
     results.duration_millis = elapsed_time(start);
     resolve(results);

--- a/lib/healthcheck/index.js
+++ b/lib/healthcheck/index.js
@@ -8,9 +8,9 @@ var logger    = require("../logger.js").getLogger({"module": __filename});
 module.exports = function () {
   var reportStart = process.hrtime();
   var report = {
-    report_as_of: new Date().toISOString(),
+    generated_at: new Date().toISOString(),
     duration_millis: 0,
-    tests: []
+    tests: {}
   };
 
   // Load up an array of promises for each (other) file in this directory
@@ -28,11 +28,15 @@ module.exports = function () {
   // Once all promises have resolved, return the report
   return Promise.all(tests)
       .then(function (results) {
-        report.tests = results;
+        results.forEach(function(result) {
+          report.tests[result.test_name] = result;
+        });
         finalizeReport(report, reportStart);
         return report;
       }).catch(function (results) {
-        report.tests = results;
+        results.forEach(function(result) {
+          report.tests[result.test_name] = result;
+        });
         finalizeReport(report, reportStart);
         return report;
       });

--- a/lib/healthcheck/redis.js
+++ b/lib/healthcheck/redis.js
@@ -16,7 +16,7 @@ function runTest(resolve, reject) {
     // a good redis connection, which means that we can't reason about the state
     // of the other dependencies. I'd rather force a timeout.
     setTimeout(function() {
-      results.test_result = "failed";
+      results.result = "failed";
       results.duration_millis = elapsed_time(start);
       results.error = "timeout";
       resolve(results);
@@ -24,16 +24,16 @@ function runTest(resolve, reject) {
     redisClient.ping(function(err, result) {
       clearTimeout();
       if (err) {
-        results.test_result = "failed";
+        results.result = "failed";
         results.error = err.message;
       } else {
-        results.test_result = "passed";
+        results.result = "passed";
       }
       results.duration_millis = elapsed_time(start);
       resolve(results);
     });
   } catch(err) {
-    results.test_result = "failed";
+    results.result = "failed";
     results.error = err;
     results.duration_millis = elapsed_time(start);
     resolve(results);

--- a/lib/healthcheck/statsd.js
+++ b/lib/healthcheck/statsd.js
@@ -16,16 +16,16 @@ function runTest(resolve, reject) {
     statsdClient.increment("healthcheck", 1, 1, function(err, bytes) {
       if (err) {
         results.error = err.message;
-        results.test_result = "failed";
+        results.result = "failed";
       } else {
-        results.test_result = "passed";
+        results.result = "passed";
       }
 
       results.duration_millis = elapsed_time(start);
       resolve(results);
     });
   } catch(err) {
-    results.test_result = "failed";
+    results.result = "failed";
     results.error = err.message;
     results.duration_millis = elapsed_time(start);
     resolve(results);

--- a/test/api/controllers/admin.js
+++ b/test/api/controllers/admin.js
@@ -78,20 +78,20 @@ describe("controllers", function() {
             }
             res.should.have.property("status", 200);
             var report = res.body;
-            report.should.have.property("report_as_of");
+            report.should.have.property("generated_at");
             report.should.have.property("duration_millis");
             report.should.have.property("tests");
             var tests = report.tests;
-            tests.length.should.be.above(0);
-            for(var index in tests) {
-              var test = tests[index];
+            Object.keys(tests).length.should.be.above(0);
+            Object.keys(tests).forEach(function(key) {
+              var test = tests[key];
               test.should.have.property("duration_millis");
               test.duration_millis.should.be.greaterThan(0);
               test.should.have.property("test_name");
-              test.should.have.property("test_result");
-              test.test_result.should.eql("passed");
+              test.should.have.property("result");
+              test.result.should.eql("passed");
               test.should.have.property("tested_at");
-            }
+            });
             done();
           });
       });


### PR DESCRIPTION
…st_result", key by component, rather than flat array, generated_at instead of report_as_of
