### PR TITLE
Increase Deployment Model Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.1.18 (August 21th, 2015)
+
+  - Increased field length for Deployment model fields package_url and arguments to 2048
+
 0.1.17 (August 20th, 2015)
 
   - Now reporting deployment.engine as a metric to statsd for POST to deployments

--- a/data/migrations/20150821130700-increaseDeploymentFieldSize.js
+++ b/data/migrations/20150821130700-increaseDeploymentFieldSize.js
@@ -2,16 +2,16 @@
 
 module.exports = {
   up: function (migration, DataTypes) {
-    migration.changeColumn('Deployments','package_url', {
+    migration.changeColumn("Deployments","package_url", {
         type:DataTypes.STRING(2048)
     });
 
-    migration.changeColumn('Deployments','arguments', {
+    migration.changeColumn("Deployments","arguments", {
         type:DataTypes.STRING(2048)
     });
   },
-  down: function (migration, Sequelize) {
-    migration.changeColumn('Deployments','package_url', DataTypes.STRING)
-    migration.changeColumn('Deployments','arguments', DataTypes.STRING)
+  down: function (migration, DataTypes) {
+    migration.changeColumn("Deployments","package_url", DataTypes.STRING);
+    migration.changeColumn("Deployments","arguments", DataTypes.STRING);
   }
 };

--- a/data/migrations/20150821130700-increaseDeploymentFieldSize.js
+++ b/data/migrations/20150821130700-increaseDeploymentFieldSize.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = {
+  up: function (migration, DataTypes) {
+    migration.changeColumn('Deployments','package_url', {
+        type:DataTypes.STRING(2048)
+    });
+
+    migration.changeColumn('Deployments','arguments', {
+        type:DataTypes.STRING(2048)
+    });
+  },
+  down: function (migration, Sequelize) {
+    migration.changeColumn('Deployments','package_url', DataTypes.STRING)
+    migration.changeColumn('Deployments','arguments', DataTypes.STRING)
+  }
+};

--- a/data/models/deployment.js
+++ b/data/models/deployment.js
@@ -11,9 +11,9 @@ module.exports = function (sequelize, DataTypes) {
         user: DataTypes.STRING,
         environment: DataTypes.STRING,
         package: DataTypes.STRING,
-        package_url: DataTypes.STRING,
+        package_url: DataTypes.STRING(2048),
         version: DataTypes.STRING,
-        arguments: DataTypes.STRING,
+        arguments: DataTypes.STRING(2048),
         result: DataTypes.STRING,
         elapsed_seconds: DataTypes.INTEGER
     }, {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "https://github.com/Cimpress-MCP/deployment-tracker.git"
   },
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "main": "app.js",
   "dependencies": {
     "bunyan": "^1.4.0",


### PR DESCRIPTION
Increasing Field Length from 255 to 2048 for deployment package_url and arguments as there have been users experiencing data truncation errors when writing to the db.
