### PR TITLE
Enable CORS support for the /swagger route only. This is intended to …

### DIFF
--- a/api/middleware/enableCors.js
+++ b/api/middleware/enableCors.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = function(req, res, next) {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  next();
+};

--- a/app.js
+++ b/app.js
@@ -7,6 +7,9 @@ var SwaggerExpress = require("swagger-express-mw");
 app = require("express")();
 module.exports = app;  // for testing
 
+// Enable CORS for the swagger route only, so that this can be used with Swagger UI.
+app.use("/swagger", require("./api/middleware/enableCors.js"));
+
 var swaggerConfig = {
   appRoot: __dirname // required config
 };

--- a/test/api/middleware/enableCors.js
+++ b/test/api/middleware/enableCors.js
@@ -1,0 +1,44 @@
+"use strict";
+
+var should = require("should");
+var request = require("supertest");
+var server = require("../../../app");
+
+process.env.A127_ENV = "test";
+
+describe("middleware", function() {
+  describe("CORS", function() {
+    it("Should be enabled for /swagger route", function(done) {
+
+      request(server)
+        .get("/swagger")
+        .end(function(err, res) {
+          if (err) {
+            throw err;
+          }
+
+          res.header.should.have.property("access-control-allow-origin");
+          res.header["access-control-allow-origin"].should.eql("*");
+          res.header.should.have.property("access-control-allow-headers");
+          res.header["access-control-allow-headers"].should.eql("Origin, X-Requested-With, Content-Type, Accept");
+
+          done();
+        });
+    });
+
+    it("Should note be enabled for other routes", function(done) {
+      request(server)
+        .get("/v1/deployments")
+        .end(function(err, res) {
+          if (err) {
+            throw err;
+          }
+
+          res.header.should.not.have.property("access-control-allow-origin");
+          res.header.should.not.have.property("access-control-allow-headers");
+
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
…allow deployment tracker's swagger endpoint to work with Swagger UI that is running on another host.

/CC @maclennann @am17torres 
