### PR TITLE
Remove backticks from all database queries for MSSQL support

### DIFF
--- a/api/controllers/servers.js
+++ b/api/controllers/servers.js
@@ -90,7 +90,7 @@ function getServerByHostname (req, res, next) {
     where: { hostname: hostname },
     limit: req.swagger.params.limit.value,
     offset: req.swagger.params.offset.value,
-    order: "`createdAt` DESC"
+    order: [ ["createdAt", "DESC"] ]
   })
     .then(function (servers) {
         if (servers.length === 0) {


### PR DESCRIPTION
do ORDER BY in getServerByHostname() the prescribed way as in getAllServers instead of the string with backticks since the backticks way seems not to work with MSSQL. seen working locally with @chrisbaldauf 
